### PR TITLE
Pass estimatedColumnSize to Grid component in time_area.tsx 

### DIFF
--- a/src/components/time_area/time_area.tsx
+++ b/src/components/time_area/time_area.tsx
@@ -47,7 +47,7 @@ export const TimeArea: FC<TimeAreaProps> = ({ setCursor, maxScaleCount, hideCurs
         return showUnit ? scaleWidth / scaleSplitCount : scaleWidth;
     }
   };
-
+  const estColumnWidth=getColumnWidth({index:1});
   return (
     <div className={prefix('time-area')}>
       <AutoSizer>
@@ -58,6 +58,7 @@ export const TimeArea: FC<TimeAreaProps> = ({ setCursor, maxScaleCount, hideCurs
                 ref={gridRef}
                 columnCount={showUnit ? scaleCount * scaleSplitCount + 1 : scaleCount}
                 columnWidth={getColumnWidth}
+                estimatedColumnSize={estColumnWidth}
                 rowCount={1}
                 rowHeight={height}
                 width={width}


### PR DESCRIPTION
Hi there,

First I want to thank you for making such a great component, you saved me a lot of time.

While using `react-timeline-editor` I noticed something strange when timeline gets longer ( for example`scaleCount=10000`, `scaleWidth=100`,`scaleSplitCount=10` ), the timebar started to scroll much faster for some reason.

Then I noticed that problem goes away if I set `scaleSplitcount` to 1.

After some digging, the problem was narrowed down to instantiating the `Grid` component from `react-virtualized`. \
Namely, since `estimatedColumnSize` was not passed down, it allocated much longer width than necessary in this case.

This PR contains fix for it.

You can also review differences in behaviour of current `reat-timeline-editor` vs the fixed one on following links:
  - current (with this issue) : https://vs6zjs.csb.app/
  - fixed : https://8xspwz.csb.app/

Let me know if I can help you in any other way

Best regards,
Mirko